### PR TITLE
fix: add disableAsciiToUnicodeParamConversion option and tests

### DIFF
--- a/src/driver/sqlserver/SqlServerConnectionOptions.ts
+++ b/src/driver/sqlserver/SqlServerConnectionOptions.ts
@@ -186,6 +186,12 @@ export interface SqlServerConnectionOptions
         readonly disableOutputReturning?: boolean
 
         /**
+         * A boolean, controlling whether MssqlParameter types char, varchar, and text are converted to their unicode equivalents, nchar, nvarchar, and ntext.
+         * (default: false, meaning that char/varchar/text parameters will be converted to nchar/nvarchar/ntext)
+         */
+        readonly disableAsciiToUnicodeParamConversion?: boolean
+
+        /**
          * Debug options
          */
         readonly debug?: {

--- a/src/driver/sqlserver/SqlServerQueryRunner.ts
+++ b/src/driver/sqlserver/SqlServerQueryRunner.ts
@@ -4049,12 +4049,33 @@ export class SqlServerQueryRunner
             case "tinyint":
                 return this.driver.mssql.TinyInt
             case "char":
+                if (
+                    this.driver.options.options
+                        ?.disableAsciiToUnicodeParamConversion
+                ) {
+                    return this.driver.mssql.Char(...parameter.params)
+                }
+                return this.driver.mssql.NChar(...parameter.params)
             case "nchar":
                 return this.driver.mssql.NChar(...parameter.params)
             case "text":
+                if (
+                    this.driver.options.options
+                        ?.disableAsciiToUnicodeParamConversion
+                ) {
+                    return this.driver.mssql.Text
+                }
+                return this.driver.mssql.Ntext
             case "ntext":
                 return this.driver.mssql.Ntext
             case "varchar":
+                if (
+                    this.driver.options.options
+                        ?.disableAsciiToUnicodeParamConversion
+                ) {
+                    return this.driver.mssql.VarChar(...parameter.params)
+                }
+                return this.driver.mssql.NVarChar(...parameter.params)
             case "nvarchar":
                 return this.driver.mssql.NVarChar(...parameter.params)
             case "xml":

--- a/test/github-issues/10131/entity/Example.ts
+++ b/test/github-issues/10131/entity/Example.ts
@@ -1,0 +1,13 @@
+import { Entity, PrimaryGeneratedColumn, Column } from "../../../../src"
+
+@Entity()
+export class Example {
+    @PrimaryGeneratedColumn("uuid")
+    id?: string
+
+    @Column("varchar", { length: 10 })
+    varCharField: string = ""
+
+    @Column("char", { length: 10 })
+    charField: string = ""
+}

--- a/test/github-issues/10131/issue-10131.ts
+++ b/test/github-issues/10131/issue-10131.ts
@@ -1,0 +1,109 @@
+import "reflect-metadata"
+import { DataSource } from "../../../src"
+import {
+    closeTestingConnections,
+    createTestingConnections,
+    reloadTestingDatabases,
+} from "../../utils/test-utils"
+import { Example } from "./entity/Example"
+import { SqlServerDriver } from "../../../src/driver/sqlserver/SqlServerDriver"
+import sinon from "sinon"
+
+describe("github issues > #10131 optional to disable ascii to unicode parameter conversion", () => {
+    let connections: DataSource[]
+
+    beforeEach(() => reloadTestingDatabases(connections))
+    afterEach(() => sinon.restore())
+
+    describe("when disableAsciiToUnicodeParamConversion is true", () => {
+        let driver: SqlServerDriver
+
+        before(async () => {
+            connections = await createTestingConnections({
+                entities: [Example],
+                enabledDrivers: ["mssql"],
+                schemaCreate: false,
+                dropSchema: true,
+                driverSpecific: {
+                    options: {
+                        disableAsciiToUnicodeParamConversion: true,
+                    },
+                },
+            })
+        })
+        after(() => closeTestingConnections(connections))
+
+        it("should disable ascii to unicode parameter conversion", () =>
+            Promise.all(
+                connections.map(async (connection) => {
+                    driver = new SqlServerDriver(connection)
+
+                    const driverNCharSpy = sinon.spy(driver.mssql, "NChar")
+                    const driverNVarCharSpy = sinon.spy(
+                        driver.mssql,
+                        "NVarChar",
+                    )
+                    const driverCharSpy = sinon.spy(driver.mssql, "Char")
+                    const driverVarCharSpy = sinon.spy(driver.mssql, "VarChar")
+
+                    const entity = new Example()
+                    entity.varCharField = "test"
+                    entity.charField = "test"
+
+                    const repo = connection.getRepository(Example)
+                    await repo.save(entity)
+
+                    sinon.assert.called(driverCharSpy)
+                    sinon.assert.called(driverVarCharSpy)
+                    sinon.assert.notCalled(driverNCharSpy)
+                    sinon.assert.notCalled(driverNVarCharSpy)
+                }),
+            ))
+    })
+
+    describe("when disableAsciiToUnicodeParamConversion is false", () => {
+        let driver: SqlServerDriver
+
+        before(async () => {
+            connections = await createTestingConnections({
+                entities: [Example],
+                enabledDrivers: ["mssql"],
+                schemaCreate: false,
+                dropSchema: true,
+                driverSpecific: {
+                    options: {
+                        disableAsciiToUnicodeParamConversion: false,
+                    },
+                },
+            })
+        })
+        after(() => closeTestingConnections(connections))
+
+        it("should not disable ascii to unicode parameter conversion", () =>
+            Promise.all(
+                connections.map(async (connection) => {
+                    driver = new SqlServerDriver(connection)
+
+                    const driverNCharSpy = sinon.spy(driver.mssql, "NChar")
+                    const driverNVarCharSpy = sinon.spy(
+                        driver.mssql,
+                        "NVarChar",
+                    )
+                    const driverCharSpy = sinon.spy(driver.mssql, "Char")
+                    const driverVarCharSpy = sinon.spy(driver.mssql, "VarChar")
+
+                    const entity = new Example()
+                    entity.varCharField = "test"
+                    entity.charField = "test"
+
+                    const repo = connection.getRepository(Example)
+                    await repo.save(entity)
+
+                    sinon.assert.notCalled(driverCharSpy)
+                    sinon.assert.notCalled(driverVarCharSpy)
+                    sinon.assert.called(driverNCharSpy)
+                    sinon.assert.called(driverNVarCharSpy)
+                }),
+            ))
+    })
+})


### PR DESCRIPTION
This adds a new property `disableAsciiToUnicodeParamConversion` to `SqlServerConnectionOptions` to control whether the MssqlParameter types char, varchar, and text are converted to their unicode equivalents, nchar, nvarchar, and ntext. This defaults to false, maintaining the current behavior.
 